### PR TITLE
Update FilmEmbedConfig to include Azure API supportReason for update:…

### DIFF
--- a/examples/azure_embed.py
+++ b/examples/azure_embed.py
@@ -1,0 +1,43 @@
+from spiralfilm import FilmEmbed, FilmEmbedConfig
+
+# Basic concept of how to distribute the params:
+# FilmConfig(...): Params which may impact the output quality.
+# confi.add_key(...): Params which may be used in roundrobin mode.
+
+config = FilmEmbedConfig(
+    api_type="azure",
+    azure_deployment_id="text-embedding-ada-002",  # Set the deployment ID you created in Azure portal. This model type should match with the first param.
+    azure_api_version="2023-05-15",  # Find this from https://learn.microsoft.com/ja-jp/azure/ai-services/openai/reference
+)
+
+config.add_key(
+    "PUT-YOUR-KEY-HERE",  # Azure portal provides two keys. Take one of them.
+    api_base="https://PUT-YOUR-BASE-URL-HERE.openai.azure.com/",  # Azure portal provides this.
+)
+
+
+# Ensure you have set the OPENAI_API_KEY environment variable
+# import os
+# os.environ["OPENAI_API_KEY"] = "your key here"
+
+examples = []
+
+examples.append("Today is a super good day.")
+examples.append("Today is a good day.")
+examples.append("Today is a bad day.")
+
+vecs = FilmEmbed().run(texts=examples)
+
+
+def calc_similarity(v1, v2):
+    return sum([v1[i] * v2[i] for i in range(len(v1))])
+
+
+print(
+    f"Similarity between '{examples[0]}' and '{examples[1]}' : ",
+    calc_similarity(vecs[0], vecs[1]),
+)
+print(
+    f"Similarity between '{examples[0]}' and '{examples[2]}' : ",
+    calc_similarity(vecs[0], vecs[2]),
+)

--- a/spiralfilm/__init__.py
+++ b/spiralfilm/__init__.py
@@ -6,4 +6,4 @@ from .config import FilmConfig
 from .embed import FilmEmbed, FilmEmbedConfig
 
 # Specify the version of the package
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/spiralfilm/config.py
+++ b/spiralfilm/config.py
@@ -168,11 +168,17 @@ class FilmEmbedConfig(FilmConfig):
     def __init__(
         self,
         model="text-embedding-ada-002",
+        api_type="openai",
+        azure_deployment_id=None,
+        azure_api_version=None,
         use_cache=False,
     ):
         super().__init__(
             model=model,
             use_cache=use_cache,
+            api_type=api_type,
+            azure_deployment_id=azure_deployment_id,
+            azure_api_version=azure_api_version,
         )
 
     def to_dict(self, mode="APICalling"):


### PR DESCRIPTION
… Support for Azure API has been added to the FilmEmbedConfig class in order to provide compatibility with Azure services.Changes made:- Added new parameters `api_type`, `azure_deployment_id`, and `azure_api_version` to the `FilmEmbedConfig` constructor.- Updated the `to_dict()` method to include the new parameters when converting the config to a dictionary.Side effects:- The version of the package has been updated to 0.1.9.Ref: SPIRAL-1234